### PR TITLE
Fixed issues with 3BRAINS files processing and added electrode noise output file

### DIFF
--- a/src/process_chan.jl
+++ b/src/process_chan.jl
@@ -36,7 +36,6 @@ TBW
         @info "Chan $(chan): $(REQ) MB to read."
         chanDATA = data[chan:4096:end] # Get the data for the channel
         realREQ = size(chanDATA, 1) * 32 / 8 / 1e6                                  # Required memory in MB
-        @info "Chan $(chan): $(realREQ) MB to read."
         DATA = Float32.(c .* chanDATA .+ d)                    # This is time consuming CHECK CHECK CHECK
     end
    
@@ -55,10 +54,8 @@ TBW
         # open(outname, "w") do f
         #     write(f, "lfp", xf)
         # end
+        
         outname = joinpath(s.OUTPUT, "lfp_$(chan).txt")
-        #open(outname, "w") do f
-        #    write(f, xf)
-        #end
         writedlm(outname, xf) # Adam: temporary solution. JLD2 files were coming out corrupted
       
 
@@ -88,6 +85,11 @@ TBW
 
         outname = joinpath(s.OUTPUT, "spk_$(chan).txt")
         writedlm(outname, tspk)
+
+        noise_outname = joinpath(s.OUTPUT, "noise.txt")
+        open(noise_outname, "a") do f
+            writedlm(f, [chan noise_std]) 
+        end
         @info "MUA: Chan $(chan) done! $(length(idx)) events detected."
     end # Spike detection --------------------------------
 
@@ -122,7 +124,7 @@ TBW
                     end_sample = ap_sample + wpost
                     wave = xf[start_sample:end_sample]
                     #write(f, "wav_$(i)", wave)
-                    writedlm(f, wave',",")
+                    writedlm(f, wave',",") # Adam: temporary solution. JLD2 files were coming out corrupted
                 end # if
             end # for
         end # open

--- a/src/process_chan.jl
+++ b/src/process_chan.jl
@@ -21,33 +21,59 @@ TBW
 @noinline function preproc_chan(fname::String, chan::Int, datasetname::String)
     file = h5open(fname, "r")                                          # Open .h5 file (on each worker)
     data = file[datasetname]                                           # Get the dataset
+
     #data = file["Data/Recording_0/AnalogStream/Stream_0/ChannelData"];# Get the dataset
-    REQ = size(data, 1) * 32 / 8 / 1e6                                  # Required memory in MB
-    #MEM = Sys.free_memory() / 1e6;                                    # Free memory in MB
-    @info "Chan $(chan): $(REQ) MB to read."
 
     c = Float32(s.c)                                            # Conversion factor (D/A)
     d = Float32(s.d)                                            # Conversion factor (D/A)
-
-    DATA = Float32.(c .* data[:, chan] .+ d)                    # This is time consuming
+    if s.type == "MCS"
+        REQ = size(data, 1) * 32 / 8 / 1e6                                  # Required memory in MB
+        #MEM = Sys.free_memory() / 1e6;                                    # Free memory in MB
+        @info "Chan $(chan): $(REQ) MB to read."
+        DATA = Float32.(c .* data[:, chan] .+ d)                    # This is time consuming
+    elseif s.type == "3BRAIN"
+        REQ = size(data, 1) * 32 / 8 / 1e6 / s.Nchans                                  # Required memory in MB
+        @info "Chan $(chan): $(REQ) MB to read."
+        chanDATA = data[chan:4096:end] # Get the data for the channel
+        realREQ = size(chanDATA, 1) * 32 / 8 / 1e6                                  # Required memory in MB
+        @info "Chan $(chan): $(realREQ) MB to read."
+        DATA = Float32.(c .* chanDATA .+ d)                    # This is time consuming CHECK CHECK CHECK
+    end
+   
 
     # LFP extraction -------------------------------------
     if s.LFP
-        xf = allocate_Float32vector(size(data, 1))
+        if s.type == "3BRAIN"
+            xf = allocate_Float32vector(Int64(size(data, 1) / s.Nchans))
+        elseif s.type == "MCS"
+            xf = allocate_Float32vector(size(data, 1)) 
+        end
         lpfilt = s.lpfilt
         xf = lowpass_and_dec(DATA, lpfilt, s.rate, s.srate)
-        outname = joinpath(s.OUTPUT, "lfp_$(chan).jld2")
-        jldsave(outname; lfp=xf) # Save the LFP to a .jld2 file
+        println("LFP: $(size(xf))")
+        # outname = joinpath(s.OUTPUT, "lfp_$(chan).jld2")
+        # open(outname, "w") do f
+        #     write(f, "lfp", xf)
+        # end
+        outname = joinpath(s.OUTPUT, "lfp_$(chan).txt")
         #open(outname, "w") do f
-        #    write(f, "lfp", xf)
+        #    write(f, xf)
         #end
+        writedlm(outname, xf) # Adam: temporary solution. JLD2 files were coming out corrupted
+      
+
         @info "LFP: Chan $(chan) done!"
         xf = nothing # Let's free some memory
     end # LFP --------------------------------------------
 
     # Spike detection ------------------------------------
     if s.detect
-        xf = allocate_Float32vector(size(data, 1))
+        if s.type == "3BRAIN"
+            xf = allocate_Float32vector(Int64(size(data, 1) / s.Nchans))
+        elseif s.type == "MCS"
+            xf = allocate_Float32vector(size(data, 1)) 
+        end
+       
         bpfilt = s.bpfilt
         xf = bandpass(DATA, bpfilt)
 
@@ -57,26 +83,24 @@ TBW
 
         #@info "Chan $(chan) - detecting spikes...";
         idx = extract_peaks(xf, thr, s.dpre, s.dpost, s.ref, s.event, s.srate)
-
-        if length(idx) == 0
-            @warn "Chan $(chan) - no spikes detected!"
-            return
-        end
-
         tspk = idx
         tspk[:, 1] = tspk[:, 1] / s.srate
 
         outname = joinpath(s.OUTPUT, "spk_$(chan).txt")
-        writedlm(outname, tspk) # Save the spike times, in seconds, to a text file
+        writedlm(outname, tspk)
         @info "MUA: Chan $(chan) done! $(length(idx)) events detected."
     end # Spike detection --------------------------------
 
 
 
-    if s.shapes && (length(idx) > 0)
+    if s.shapes
         if s.fmin_s != s.fmin_d || s.fmax_s != s.fmax_d
             @warn "Different filters for spike detection and shapes!"
-            xf = allocate_Float32vector(size(data, 1))
+            if s.type == "3BRAIN"
+            xf = allocate_Float32vector(Int64(size(data, 1) / s.Nchans))
+        elseif s.type == "MCS"
+            xf = allocate_Float32vector(size(data, 1)) 
+        end
             bpfilt_s = s.bpfilt_s
             xf = bandpass(DATA, bpfilt_s)
 
@@ -88,12 +112,17 @@ TBW
         wpre = Int32(ceil(1e-3 * s.dpre * s.srate))   # Pre window, in samples
         wpost = Int32(ceil(1e-3 * s.dpost * s.srate))   # Post window, in samples
 
-        outname = joinpath(s.OUTPUT, "spk_shapes_c$(chan).jld2")
-        jldopen(outname, "a+") do f
+        outname = joinpath(s.OUTPUT, "wav_shapes_c$(chan).txt")
+        #outname = joinpath(s.OUTPUT, "wav_shapes_c$(chan).jld2")
+        open(outname, "a") do f
             for i in eachindex(idx[:, 1])
-                if idx[i, 1] - wpre > 0 && idx[i] + wpost < length(xf)
-                    wave = xf[idx[i, 1]-wpre:idx[i, 1]+wpost]
-                    write(f, "wav_$(i)", wave)
+                ap_sample = Int32(ceil(idx[i, 1] * s.srate))
+                if ap_sample - wpre > 0 && ap_sample + wpost < length(xf)
+                    start_sample = ap_sample - wpre
+                    end_sample = ap_sample + wpost
+                    wave = xf[start_sample:end_sample]
+                    #write(f, "wav_$(i)", wave)
+                    writedlm(f, wave',",")
                 end # if
             end # for
         end # open

--- a/src/readTOML.jl
+++ b/src/readTOML.jl
@@ -69,17 +69,17 @@ function parse_toml_files(OUTPUT)::settings
         d = -ADZero * c                       # Conversion from AD to physical units (V)
         #----------------------------------------------
     elseif type == "3BRAIN"
-        #srate = parse(Float64, infofile["info"]["FrameRate"])          # Sampling rate in Hz
         srate = infofile["info"]["FrameRate"]          # Sampling rate in Hz
+       
+        # These could be excluded, 3BRAINS does not have these values
+        # but the function still wants to output them
+        #----------------------------------------------
         Tick = 0
-        #Tick = (1 / srate) * 1E6; # tick in us
         ADZero = 0
         ConversionFactor = 0 # D/A conversion factor
         Exponent = 0
-        # maxA = parse(Float64, infofile["info"]["MaxAnalogValue"])
-        # minA = parse(Float64, infofile["info"]["MinAnalogValue"])
-        # maxD = parse(Float64, infofile["info"]["MaxDigitalValue"])
-        # minD = parse(Float64, infofile["info"]["MinDigitalValue"])
+        #----------------------------------------------
+
         maxA = infofile["info"]["MaxAnalogValue"]
         minA = infofile["info"]["MinAnalogValue"]
         maxD = infofile["info"]["MaxDigitalValue"]

--- a/src/readTOML.jl
+++ b/src/readTOML.jl
@@ -24,7 +24,7 @@ function parse_toml_files(OUTPUT)::settings
     end
 
     configfile = TOML.parsefile(config)
-    LFP = configfile["lfp"]["save_lfp"] == "y"
+    LFP = configfile["lfp"]["save_lfp"] == "n"
     fmax = configfile["lfp"]["fmax"]
     rate = configfile["lfp"]["rate"]
 
@@ -53,26 +53,47 @@ function parse_toml_files(OUTPUT)::settings
     end
 
     infofile = TOML.parsefile(meta)
+    type = infofile["info"]["type"]          # Type of data
     Nchans = infofile["info"]["Nchans"]     # Number of channels
     Nsamples = infofile["info"]["Nsamples"]   # Number of samples per channel
 
-    Tick = infofile["chans"]["Tick"]      # Sampling interval in us
-    ADZero = infofile["chans"]["ADZero"]    # ADZero
-    ConversionFactor = infofile["chans"]["ConversionFactor"] # D/A conversion factor
-    Exponent = infofile["chans"]["Exponent"]  # Exponent for the conversion factor
-    #----------------------------------------------
-    srate = 1E6 / Tick                    # Sampling rate in Hz (Float32)
-    c = ConversionFactor * 10.0^Exponent  # Conversion from AD to physical units (V)
-    d = -ADZero * c                       # Conversion from AD to physical units (V)
-    #----------------------------------------------
-
+    if type == "MCS"
+        
+        Tick = infofile["chans"]["Tick"]      # Sampling interval in us
+        ADZero = infofile["chans"]["ADZero"]    # ADZero
+        ConversionFactor = infofile["chans"]["ConversionFactor"] # D/A conversion factor
+        Exponent = infofile["chans"]["Exponent"]  # Exponent for the conversion factor
+        #----------------------------------------------
+        srate = 1E6 / Tick                          # Sampling rate in Hz
+        c = ConversionFactor * 10.0^Exponent  # Conversion from AD to physical units (V)
+        d = -ADZero * c                       # Conversion from AD to physical units (V)
+        #----------------------------------------------
+    elseif type == "3BRAIN"
+        #srate = parse(Float64, infofile["info"]["FrameRate"])          # Sampling rate in Hz
+        srate = infofile["info"]["FrameRate"]          # Sampling rate in Hz
+        Tick = 0
+        #Tick = (1 / srate) * 1E6; # tick in us
+        ADZero = 0
+        ConversionFactor = 0 # D/A conversion factor
+        Exponent = 0
+        # maxA = parse(Float64, infofile["info"]["MaxAnalogValue"])
+        # minA = parse(Float64, infofile["info"]["MinAnalogValue"])
+        # maxD = parse(Float64, infofile["info"]["MaxDigitalValue"])
+        # minD = parse(Float64, infofile["info"]["MinDigitalValue"])
+        maxA = infofile["info"]["MaxAnalogValue"]
+        minA = infofile["info"]["MinAnalogValue"]
+        maxD = infofile["info"]["MaxDigitalValue"]
+        minD = infofile["info"]["MinDigitalValue"]
+        c = (maxA - minA) / (maxD - minD)
+        d = minA
+    end
     # Convert fmin_d, fmax_d, fmin_s, fmax_s, dpre, dpost to Float32, before calling the functions
     bpfilt = SpQEphysTools.prepare_bandpass(Float32(fmin_d), Float32(fmax_d), Float32(srate))
     bpfilt_s = SpQEphysTools.prepare_bandpass(Float32(fmin_s), Float32(fmax_s), Float32(srate))
     lpfilt = SpQEphysTools.prepare_lowpass(Float32(fmax), Float32(srate))
 
     #-- Settings struct ---------------------------
-    return SpQEphysTools.settings(OUTPUT, LFP, fmax, rate, detect, fmin_d, fmax_d, stdmin, stdmax, event, ref, shapes, fmin_s, fmax_s, dpre, dpost, factor, spline, Nchans, Nsamples, Tick, ADZero, ConversionFactor, Exponent, srate, c, d, lpfilt, bpfilt, bpfilt_s)
+    return SpQEphysTools.settings(OUTPUT, LFP, type, fmax, rate, detect, fmin_d, fmax_d, stdmin, stdmax, event, ref, shapes, fmin_s, fmax_s, dpre, dpost, factor, spline, Nchans, Nsamples, Tick, ADZero, ConversionFactor, Exponent, srate, c, d, lpfilt, bpfilt, bpfilt_s)
 
 end # function parse_toml_files ----------------
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -18,6 +18,7 @@ const ZPG = DSP.Filters.ZeroPoleGain{:z,ComplexF32,ComplexF32,Float32}; # Type a
 @with_kw mutable struct settings
   OUTPUT::String = ""  # Output directory
   LFP::Bool = false  # Extract LFP
+  type::String = "" # Type of data (MCS or 3BRAIN)
   fmax::Float32 = 0.0 # Low-pass cutoff frequency for LFP
   rate::Float32 = 0.0 # Decimation rate for LFP
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -79,7 +79,6 @@ function tideup_output(OUTPUT)
         if isfile(noise_outname) && filesize(noise_outname) > 0
             noise = readdlm(noise_outname)
             # sort through the electrode numbers and re-write in order
-
             noise = sortslices(noise, dims=1)
             writedlm(noise_outname, noise)
         end

--- a/src/write.jl
+++ b/src/write.jl
@@ -73,4 +73,16 @@ function tideup_output(OUTPUT)
         writedlm(OUTPUT * "/spk.txt", all_spk)
     end
 
+    # Clean and organize the noise file
+    if s.detect
+        noise_outname = OUTPUT * "/noise.txt"
+        if isfile(noise_outname) && filesize(noise_outname) > 0
+            noise = readdlm(noise_outname)
+            # sort through the electrode numbers and re-write in order
+
+            noise = sortslices(noise, dims=1)
+            writedlm(noise_outname, noise)
+        end
+    end
+
 end


### PR DESCRIPTION
readTOML.jl:
I added the correct calls to get the chans information
Updated the function output to include "type"

process_chan.jl:
added the correct way to load 3BRAINS channel data
Put a temporary solution for LFP and waveforms because the JLD2 files were coming out corrupted and unreadable - I didn't update the output clean-up taking this into account
Added the electrode noise output to a separate txt

write.jl
Fixed the clean-up of the waveforms (it was not considering the actual name of the output files)
Added a loop to organize the noise output
