### PR TITLE
Fixed the noise output file

### DIFF
--- a/src/process_chan.jl
+++ b/src/process_chan.jl
@@ -86,10 +86,9 @@ TBW
         outname = joinpath(s.OUTPUT, "spk_$(chan).txt")
         writedlm(outname, tspk)
 
-        noise_outname = joinpath(s.OUTPUT, "noise.txt")
-        open(noise_outname, "a") do f
-            writedlm(f, [chan noise_std]) 
-        end
+        noise_outname = joinpath(s.OUTPUT, "noise_$(chan).txt")
+        writedlm(noise_outname, noise_std) 
+        
         @info "MUA: Chan $(chan) done! $(length(idx)) events detected."
     end # Spike detection --------------------------------
 


### PR DESCRIPTION
process_chan.jl
Changed the noise output to generate a file with a single value per channel. Doing it directly was leading to loss of some channels (multiple workers accessing the same file and appending simultaneously)

write.jl
Added the tidy-up for the noise: moving all single channel tmp files into a folder; generating the "real" file with all channels; deleting the tmp files.